### PR TITLE
Small fixes

### DIFF
--- a/aqc_dwave.py
+++ b/aqc_dwave.py
@@ -80,6 +80,8 @@ def main(args):
     answers = solver.sample_qubo(Q, **params)
     solve_time = time.time() - t0
 
+    client.close()
+
     for i in range(len(answers['energies'])):
         print('%f - %d' % (answers['energies'][i], answers['num_occurrences'][i]))
 

--- a/mip_gurobi.py
+++ b/mip_gurobi.py
@@ -134,7 +134,7 @@ def build_cli_parser():
     parser.add_argument('-f', '--input-file', help='the data file to operate on (.json)')
 
     parser.add_argument('-ss', '--show-solution', help='print the solution', action='store_true', default=False)
-    parser.add_argument('-rtl', '--runtime-limit', help='gurobi runtime limit (sec.)', type=int)
+    parser.add_argument('-rtl', '--runtime-limit', help='gurobi runtime limit (sec.)', type=float)
     parser.add_argument('-tl', '--thread-limit', help='gurobi thread limit', type=int, default=1)
     parser.add_argument('-cuts', help='gurobi cuts parameter', type=int)
 

--- a/miqp_gurobi.py
+++ b/miqp_gurobi.py
@@ -126,7 +126,7 @@ def build_cli_parser():
     parser.add_argument('-f', '--input-file', help='the data file to operate on (.json)')
 
     parser.add_argument('-ss', '--show-solution', help='print the solution', action='store_true', default=False)
-    parser.add_argument('-rtl', '--runtime-limit', help='gurobi runtime limit (sec.)', type=int)
+    parser.add_argument('-rtl', '--runtime-limit', help='gurobi runtime limit (sec.)', type=float)
     parser.add_argument('-tl', '--thread-limit', help='gurobi thread limit', type=int, default=1)
     parser.add_argument('-cuts', help='gurobi cuts parameter', type=int)
 


### PR DESCRIPTION
* Change the command line option type of Gurobi runtime limit from int to float.
* Close dwave.cloud.Client after finishing using it, because I observed that there was a memory leak in aqc_dwave.py after calling it for many times.